### PR TITLE
Fix SIGTRAP crash on import (GtkTextView log insert)

### DIFF
--- a/FTBDatabaseHandler.py
+++ b/FTBDatabaseHandler.py
@@ -1,7 +1,16 @@
 import os
+import re
 import sqlite3
 import traceback
 from ftb_shared import *
+
+# FTB stores binary control bytes inside some text columns (e.g. a trailing
+# blob on date fields). Those bytes (NUL and other C0 controls) crash the
+# GTK TextView log insert with a fatal g_log (SIGTRAP, not catchable in Python).
+# Strip C0 control chars on decode, keeping tab/newline/carriage-return.
+_FTB_CTRL_RE = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+def _ftb_decode(b):
+    return _FTB_CTRL_RE.sub('', b.decode(errors='ignore'))
 
 FTB_DIR_NAME = "myheritage"
 FTB_DB_DIR_NAME = "database"
@@ -16,7 +25,7 @@ class FTBDatabaseHandler:
         self.dbPath = self.find_ftb_file(self.dbPath)
         if not self.dbPath: raise FileNotFoundError
         conn = sqlite3.connect(self.dbPath, check_same_thread=False)
-        conn.text_factory = lambda b: b.decode(errors = 'ignore')
+        conn.text_factory = _ftb_decode
         cursor = conn.cursor()
         return cursor, conn
 

--- a/ftb_gramps_sync.py
+++ b/ftb_gramps_sync.py
@@ -822,11 +822,27 @@ class FTB_Gramps_sync(BatchTool, ManagedWindow):
 
         return pageN + 1
 
+    # Max lines kept in the GUI log TextView. The processing loop runs in a
+    # single blocking main-loop callback, so the buffer never gets a chance to
+    # be re-validated/redrawn; on large imports the ever-growing text btree
+    # eventually triggers a fatal g_log (SIGTRAP) on insert. Cap it.
+    LOG_MAX_LINES = 2000
+
     def _log(self, s):
-        buffer = self.progress_page.log_text_view.get_buffer()
-        end_iter = buffer.get_end_iter()
-        buffer.insert(end_iter, f"{s}\n")
-        print(s)
+        # Strip C0 control chars (NUL etc. from FTB data) that crash GtkTextView.
+        safe = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f]', '', str(s))
+        try:
+            buffer = self.progress_page.log_text_view.get_buffer()
+            line_count = buffer.get_line_count()
+            if line_count > self.LOG_MAX_LINES:
+                start = buffer.get_start_iter()
+                cut = buffer.get_iter_at_line(line_count - self.LOG_MAX_LINES)
+                buffer.delete(start, cut)
+            end_iter = buffer.get_end_iter()
+            buffer.insert(end_iter, f"{safe}\n")
+        except Exception as e:
+            print(f"[FTBImport log suppressed]: {e}")
+        print(safe)
 
     def log(self, s):
         # GLib.idle_add(self._log, s)


### PR DESCRIPTION
Importing a real FTB project crashed Gramps mid-import with EXC_BREAKPOINT/ SIGTRAP. Stack: gtk_text_buffer insert -> fatal g_log. Two root causes:

1. FTB stores binary control bytes inside some text columns (trailing blob on date fields). Decoding with errors='ignore' keeps NUL and other C0 control chars, which crash GtkTextView insert via a fatal g_log. Fixed by stripping C0 control chars in the SQLite text_factory (keeping \t \n \r).

2. The whole import runs in one blocking main-loop callback, so the log TextView buffer is never re-validated/redrawn and grows unbounded; on large trees the text btree insert eventually aborts. Cap the buffer to the last 2000 lines and guard the insert.

Tested: full import of a ~2200-person / ~2700-photo project now completes without crashing.

This possibly also fixes #7, the behaviour described there matches my behaviour.